### PR TITLE
correct module "cross_validation" to "model_selection"

### DIFF
--- a/CMN/IEMOCAP/cmn.py
+++ b/CMN/IEMOCAP/cmn.py
@@ -2,7 +2,7 @@ import tensorflow as tf
 import numpy as np
 import sys
 import tensorflow.contrib.rnn as rnn_cell
-from sklearn.cross_validation import train_test_split
+from sklearn.model_selection import train_test_split
 
 
 

--- a/CMN/IEMOCAP/utils_cmn.py
+++ b/CMN/IEMOCAP/utils_cmn.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 import pickle
-from sklearn import cross_validation, metrics
+from sklearn import model_selection, metrics
 
 TEXT_EMBEDDINGS = "./IEMOCAP/data/text/IEMOCAP_text_embeddings.pickle"
 VIDEO_EMBEDDINGS = "./IEMOCAP/data/video/IEMOCAP_video_features.pickle"
@@ -9,7 +9,7 @@ AUDIO_EMBEDDINGS = "./IEMOCAP/data/audio/IEMOCAP_audio_features.pickle"
 
 trainID = pickle.load(open("./IEMOCAP/data/trainID.pkl",'rb'), encoding="latin1")
 testID = pickle.load(open("./IEMOCAP/data/testID.pkl",'rb'), encoding="latin1")
-valID,_ = cross_validation.train_test_split(testID, test_size=.4, random_state=1227)
+valID,_ = model_selection.train_test_split(testID, test_size=.4, random_state=1227)
 # valID = testID
 
 transcripts, labels, own_historyID, other_historyID, own_historyID_rank, other_historyID_rank = pickle.load(open("./IEMOCAP/data/dataset.pkl",'rb'), encoding="latin1")

--- a/CMN/train_iemocap.py
+++ b/CMN/train_iemocap.py
@@ -5,7 +5,7 @@ import pandas as pd
 from IEMOCAP.utils_cmn import *
 from IEMOCAP.cmn import *
 import os
-from sklearn import cross_validation, metrics
+from sklearn import model_selection, metrics
 from sklearn.metrics import classification_report
 from sklearn.metrics import confusion_matrix
 

--- a/ICON/IEMOCAP/model.py
+++ b/ICON/IEMOCAP/model.py
@@ -2,7 +2,7 @@ import tensorflow as tf
 import numpy as np
 import sys
 import tensorflow.contrib.rnn as rnn_cell
-from sklearn.cross_validation import train_test_split
+from sklearn.model_selection import train_test_split
 
 
 

--- a/ICON/IEMOCAP/utils.py
+++ b/ICON/IEMOCAP/utils.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pandas as pd
 import pickle
-from sklearn import cross_validation, metrics
+from sklearn import model_selection, metrics
 
 TEXT_EMBEDDINGS = "./IEMOCAP/data/text/IEMOCAP_text_embeddings.pickle"
 VIDEO_EMBEDDINGS = "./IEMOCAP/data/video/IEMOCAP_video_features.pickle"
@@ -9,7 +9,7 @@ AUDIO_EMBEDDINGS = "./IEMOCAP/data/audio/IEMOCAP_audio_features.pickle"
 
 trainID = pickle.load(open("./IEMOCAP/data/trainID.pkl",'rb'), encoding="latin1")
 testID = pickle.load(open("./IEMOCAP/data/testID.pkl",'rb'), encoding="latin1")
-valID,_ = cross_validation.train_test_split(testID, test_size=.4, random_state=1227)
+valID,_ = model_selection.train_test_split(testID, test_size=.4, random_state=1227)
 # valID = testID
 
 transcripts, labels, own_historyID, other_historyID, own_historyID_rank, other_historyID_rank = pickle.load(open("./IEMOCAP/data/dataset.pkl",'rb'), encoding="latin1")

--- a/ICON/train_iemocap.py
+++ b/ICON/train_iemocap.py
@@ -4,7 +4,7 @@ import pandas as pd
 from IEMOCAP.utils import *
 from IEMOCAP.model import *
 import os
-from sklearn import cross_validation, metrics
+from sklearn import model_selection, metrics
 from sklearn.metrics import classification_report
 from sklearn.metrics import confusion_matrix
 


### PR DESCRIPTION
From scikit-learn ver0.20, sklearn.cross_vlidation was extinguished, and have to use sklearn.model_selection.
Since your requirements are scikit_learn==0.20.0, I replaced 'cross_vlidation' to 'model_selection'.